### PR TITLE
Fix configurable Secure flag on session and CSRF cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=8080
+DATABASE_URL=postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable
+RANKING_GRAVITY=1.5
+SECURE_COOKIES=false

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,11 +9,11 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/caarlos0/env/v11"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
@@ -27,6 +27,13 @@ import (
 	"github.com/trishtzy/warren/templates"
 )
 
+type config struct {
+	Port           string  `env:"PORT"            envDefault:"8080"`
+	DatabaseURL    string  `env:"DATABASE_URL"    envDefault:"postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable"`
+	RankingGravity float64 `env:"RANKING_GRAVITY" envDefault:"1.5"`
+	SecureCookies  bool    `env:"SECURE_COOKIES"  envDefault:"true"`
+}
+
 func fatal(msg string, args ...any) {
 	slog.Error(msg, args...)
 	os.Exit(1)
@@ -35,20 +42,19 @@ func fatal(msg string, args ...any) {
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
+	cfg, err := env.ParseAs[config]()
+	if err != nil {
+		fatal("unable to parse config", "error", err)
 	}
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		databaseURL = "postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable"
+	if !cfg.SecureCookies {
+		slog.Warn("secure cookies disabled — do not use in production")
 	}
 
 	ctx := context.Background()
 
 	// Run goose migrations before opening the connection pool.
-	sqlDB, err := sql.Open("pgx", databaseURL)
+	sqlDB, err := sql.Open("pgx", cfg.DatabaseURL)
 	if err != nil {
 		fatal("unable to open database for migrations", "error", err)
 	}
@@ -68,7 +74,7 @@ func main() {
 	}
 	slog.Info("migrations applied", "version", version)
 
-	pool, err := pgxpool.New(ctx, databaseURL)
+	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)
 	if err != nil {
 		fatal("unable to connect to database", "error", err)
 	}
@@ -115,21 +121,12 @@ func main() {
 		tmpl[name] = t
 	}
 
-	gravity := ranking.DefaultGravity
-	if v := os.Getenv("RANKING_GRAVITY"); v != "" {
-		if g, err := strconv.ParseFloat(v, 64); err == nil && g > 0 {
-			gravity = g
-		}
+	gravity := cfg.RankingGravity
+	if gravity <= 0 {
+		gravity = ranking.DefaultGravity
 	}
 
-	// SECURE_COOKIES defaults to true. Set to "false" for local dev over plain HTTP.
-	secureCookies := true
-	if v := os.Getenv("SECURE_COOKIES"); strings.EqualFold(v, "false") || v == "0" {
-		secureCookies = false
-		slog.Warn("secure cookies disabled — do not use in production")
-	}
-
-	authHandler := handler.NewAuthHandler(authService, queries, tmpl, secureCookies)
+	authHandler := handler.NewAuthHandler(authService, queries, tmpl, cfg.SecureCookies)
 	postHandler := handler.NewPostHandler(postService, commentService, queries, tmpl, gravity)
 	commentHandler := handler.NewCommentHandler(commentService, queries, tmpl)
 
@@ -140,9 +137,9 @@ func main() {
 
 	// Wrap the entire mux with middleware.
 	// CSRF runs first (outermost), then Auth injects agent info.
-	wrappedMux := middleware.CSRF(secureCookies)(middleware.Auth(queries)(mux))
+	wrappedMux := middleware.CSRF(cfg.SecureCookies)(middleware.Auth(queries)(mux))
 
-	addr := ":" + port
+	addr := ":" + cfg.Port
 	server := &http.Server{
 		Addr:         addr,
 		Handler:      wrappedMux,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -122,7 +122,14 @@ func main() {
 		}
 	}
 
-	authHandler := handler.NewAuthHandler(authService, queries, tmpl)
+	// SECURE_COOKIES defaults to true. Set to "false" for local dev over plain HTTP.
+	secureCookies := true
+	if v := os.Getenv("SECURE_COOKIES"); strings.EqualFold(v, "false") || v == "0" {
+		secureCookies = false
+		slog.Warn("secure cookies disabled — do not use in production")
+	}
+
+	authHandler := handler.NewAuthHandler(authService, queries, tmpl, secureCookies)
 	postHandler := handler.NewPostHandler(postService, commentService, queries, tmpl, gravity)
 	commentHandler := handler.NewCommentHandler(commentService, queries, tmpl)
 
@@ -133,7 +140,7 @@ func main() {
 
 	// Wrap the entire mux with middleware.
 	// CSRF runs first (outermost), then Auth injects agent info.
-	wrappedMux := middleware.CSRF(middleware.Auth(queries)(mux))
+	wrappedMux := middleware.CSRF(secureCookies)(middleware.Auth(queries)(mux))
 
 	addr := ":" + port
 	server := &http.Server{

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,9 @@
             default = devenv.lib.mkShell {
               inherit inputs pkgs;
               modules = [
-                {
+                (let
+                  dbUrl = "postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable";
+                in {
                   languages.go = {
                     enable = true;
                   };
@@ -112,11 +114,11 @@
                     '';
 
                     migrate-up.exec = ''
-                      goose -dir migrations postgres "postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable" up
+                      goose -dir migrations postgres "${dbUrl}" up
                     '';
 
                     migrate-down.exec = ''
-                      goose -dir migrations postgres "postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable" down
+                      goose -dir migrations postgres "${dbUrl}" down
                     '';
 
                     generate.exec = ''
@@ -134,7 +136,7 @@
 
                   env = {
                     PORT = "8080";
-                    DATABASE_URL = "postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable";
+                    DATABASE_URL = dbUrl;
                     RANKING_GRAVITY = "1.5";
                     SECURE_COOKIES = "false";
                   };
@@ -151,7 +153,7 @@
                     echo ""
                     echo "Commands: build, dev, test, lint, fmt, migrate-up, migrate-down, generate, clean, e2e"
                   '';
-                }
+                })
               ];
             };
           });

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
               pname = "warren";
               version = self.shortRev or self.dirtyShortRev or "dev";
               src = ./.;
-              vendorHash = "sha256-ZZDIpaLwZFDYwYGrSZal+8kG0jgLjf71267IwagD2Bo=";
+              vendorHash = "sha256-y4fiQDa6R0cR74C2tWprSag4gIJ9BtsGLvrX+oBbknA=";
               subPackages = [ "cmd/server" ];
               ldflags = [ "-s" "-w" ];
               env.CGO_ENABLED = "0";

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,13 @@
                     '';
                   };
 
+                  env = {
+                    PORT = "8080";
+                    DATABASE_URL = "postgresql://rabbithole:rabbithole@127.0.0.1:5433/rabbithole?sslmode=disable";
+                    RANKING_GRAVITY = "1.5";
+                    SECURE_COOKIES = "false";
+                  };
+
                   enterShell = ''
                     echo "rabbit-hole dev environment loaded"
                     echo "  go:    $(go version | cut -d' ' -f3)"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/trishtzy/warren
 go 1.25.7
 
 require (
+	github.com/caarlos0/env/v11 v11.4.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/pressly/goose/v3 v3.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/caarlos0/env/v11 v11.4.0 h1:Kcb6t5kIIr4XkoQC9AF2j+8E1Jsrl3Wz/hhm1LtoGAc=
+github.com/caarlos0/env/v11 v11.4.0/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -22,14 +22,15 @@ type Templates map[string]*template.Template
 
 // AuthHandler handles HTTP requests for registration, login, logout, and profiles.
 type AuthHandler struct {
-	svc     *service.AuthService
-	queries *db.Queries
-	tmpl    Templates
+	svc           *service.AuthService
+	queries       *db.Queries
+	tmpl          Templates
+	secureCookies bool
 }
 
 // NewAuthHandler creates a new AuthHandler.
-func NewAuthHandler(svc *service.AuthService, queries *db.Queries, tmpl Templates) *AuthHandler {
-	return &AuthHandler{svc: svc, queries: queries, tmpl: tmpl}
+func NewAuthHandler(svc *service.AuthService, queries *db.Queries, tmpl Templates, secureCookies bool) *AuthHandler {
+	return &AuthHandler{svc: svc, queries: queries, tmpl: tmpl, secureCookies: secureCookies}
 }
 
 // pageData is the base data passed to every template.
@@ -73,26 +74,26 @@ func executeTemplate(tmpl Templates, w http.ResponseWriter, name string, data an
 }
 
 // setSessionCookie sets the session cookie on the response.
-func setSessionCookie(w http.ResponseWriter, token string) {
+func setSessionCookie(w http.ResponseWriter, token string, secure bool) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",
 		Value:    token,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   true, // M1: always set Secure flag
+		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   sessionCookieMaxAge,
 	})
 }
 
 // clearSessionCookie removes the session cookie.
-func clearSessionCookie(w http.ResponseWriter) {
+func clearSessionCookie(w http.ResponseWriter, secure bool) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",
 		Value:    "",
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,
 	})
@@ -164,7 +165,7 @@ func (h *AuthHandler) DoRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setSessionCookie(w, token)
+	setSessionCookie(w, token, h.secureCookies)
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
@@ -210,7 +211,7 @@ func (h *AuthHandler) DoLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setSessionCookie(w, token)
+	setSessionCookie(w, token, h.secureCookies)
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
@@ -222,7 +223,7 @@ func (h *AuthHandler) DoLogout(w http.ResponseWriter, r *http.Request) {
 			slog.Error("logout error", "error", logoutErr)
 		}
 	}
-	clearSessionCookie(w)
+	clearSessionCookie(w, h.secureCookies)
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 

--- a/internal/middleware/csrf.go
+++ b/internal/middleware/csrf.go
@@ -99,51 +99,51 @@ func unmaskToken(maskedHex string) (string, bool) {
 func CSRF(secureCookies bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var token string
-		cookie, err := r.Cookie(csrfCookieName)
-		if err == nil && isValidTokenFormat(cookie.Value) {
-			token = cookie.Value
-		} else {
-			token, err = generateToken()
-			if err != nil {
+			var token string
+			cookie, err := r.Cookie(csrfCookieName)
+			if err == nil && isValidTokenFormat(cookie.Value) {
+				token = cookie.Value
+			} else {
+				token, err = generateToken()
+				if err != nil {
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+					return
+				}
+				http.SetCookie(w, &http.Cookie{
+					Name:     csrfCookieName,
+					Value:    token,
+					Path:     "/",
+					HttpOnly: true,
+					Secure:   secureCookies,
+					SameSite: http.SameSiteLaxMode,
+				})
+			}
+
+			// Validate on state-changing methods.
+			switch r.Method {
+			case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+				if parseErr := r.ParseForm(); parseErr != nil {
+					http.Error(w, "bad request", http.StatusBadRequest)
+					return
+				}
+				formToken := r.FormValue(csrfFieldName)
+				unmasked, ok := unmaskToken(formToken)
+				if !ok || !tokensMatch(token, unmasked) {
+					http.Error(w, "forbidden - invalid CSRF token", http.StatusForbidden)
+					return
+				}
+			}
+
+			// Generate masked token for templates.
+			maskedToken, maskErr := maskToken(token)
+			if maskErr != nil {
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			http.SetCookie(w, &http.Cookie{
-				Name:     csrfCookieName,
-				Value:    token,
-				Path:     "/",
-				HttpOnly: true,
-				Secure:   secureCookies,
-				SameSite: http.SameSiteLaxMode,
-			})
-		}
 
-		// Validate on state-changing methods.
-		switch r.Method {
-		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
-			if parseErr := r.ParseForm(); parseErr != nil {
-				http.Error(w, "bad request", http.StatusBadRequest)
-				return
-			}
-			formToken := r.FormValue(csrfFieldName)
-			unmasked, ok := unmaskToken(formToken)
-			if !ok || !tokensMatch(token, unmasked) {
-				http.Error(w, "forbidden - invalid CSRF token", http.StatusForbidden)
-				return
-			}
-		}
-
-		// Generate masked token for templates.
-		maskedToken, maskErr := maskToken(token)
-		if maskErr != nil {
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Vary", "Cookie")
-		ctx := context.WithValue(r.Context(), csrfTokenKey, maskedToken)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
+			w.Header().Set("Vary", "Cookie")
+			ctx := context.WithValue(r.Context(), csrfTokenKey, maskedToken)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
 	}
 }

--- a/internal/middleware/csrf.go
+++ b/internal/middleware/csrf.go
@@ -93,8 +93,12 @@ func unmaskToken(maskedHex string) (string, bool) {
 // in the request context (accessible via CSRFToken). On state-changing methods
 // (POST, PUT, PATCH, DELETE), it validates that the form field csrf_token
 // unmasks to match the cookie value.
-func CSRF(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//
+// The secureCookies parameter controls the Secure flag on the CSRF cookie.
+// Set to false for local development over plain HTTP.
+func CSRF(secureCookies bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var token string
 		cookie, err := r.Cookie(csrfCookieName)
 		if err == nil && isValidTokenFormat(cookie.Value) {
@@ -110,7 +114,7 @@ func CSRF(next http.Handler) http.Handler {
 				Value:    token,
 				Path:     "/",
 				HttpOnly: true,
-				Secure:   true,
+				Secure:   secureCookies,
 				SameSite: http.SameSiteLaxMode,
 			})
 		}
@@ -141,4 +145,5 @@ func CSRF(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), csrfTokenKey, maskedToken)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+	}
 }

--- a/internal/middleware/csrf_test.go
+++ b/internal/middleware/csrf_test.go
@@ -15,7 +15,7 @@ var dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request)
 })
 
 func TestCSRF_SetsCookieOnGET(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 
@@ -53,7 +53,7 @@ func TestCSRF_InjectsTokenInContext(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := CSRF(inner)
+	handler := CSRF(true)(inner)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 
@@ -69,7 +69,7 @@ func TestCSRF_InjectsTokenInContext(t *testing.T) {
 }
 
 func TestCSRF_POST_ValidToken(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 
 	// Step 1: GET to obtain cookie and masked token.
 	var maskedToken string
@@ -77,7 +77,7 @@ func TestCSRF_POST_ValidToken(t *testing.T) {
 		maskedToken = CSRFToken(r)
 		w.WriteHeader(http.StatusOK)
 	})
-	getHandler := CSRF(inner)
+	getHandler := CSRF(true)(inner)
 	getReq := httptest.NewRequest(http.MethodGet, "/", nil)
 	getRec := httptest.NewRecorder()
 	getHandler.ServeHTTP(getRec, getReq)
@@ -108,7 +108,7 @@ func TestCSRF_POST_ValidToken(t *testing.T) {
 }
 
 func TestCSRF_POST_MissingToken(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 
 	// GET to obtain cookie.
 	getReq := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -136,7 +136,7 @@ func TestCSRF_POST_MissingToken(t *testing.T) {
 }
 
 func TestCSRF_POST_InvalidToken(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 
 	// GET to obtain cookie.
 	getReq := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -166,7 +166,7 @@ func TestCSRF_POST_InvalidToken(t *testing.T) {
 }
 
 func TestCSRF_POST_WrongToken(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 
 	// GET to obtain cookie.
 	getReq := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -205,7 +205,7 @@ func TestCSRF_POST_WrongToken(t *testing.T) {
 }
 
 func TestCSRF_POST_NoCookie(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 
 	// POST with a form token but no cookie — the middleware will generate a
 	// new cookie, but the form token won't match the fresh cookie.
@@ -223,7 +223,7 @@ func TestCSRF_POST_NoCookie(t *testing.T) {
 }
 
 func TestCSRF_GET_DoesNotValidate(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 
 	// GET request should pass even without any token.
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -288,7 +288,7 @@ func TestMaskProducesDifferentValues(t *testing.T) {
 }
 
 func TestCSRF_ReusesCookieOnSubsequentGET(t *testing.T) {
-	handler := CSRF(dummyHandler)
+	handler := CSRF(true)(dummyHandler)
 
 	// First GET — sets cookie.
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
## Summary

Follow-up to #20 code review finding: `Secure: true` was hardcoded on session and CSRF cookies, breaking local dev over plain HTTP.

## Changes

- `cmd/server/main.go` — add `SECURE_COOKIES` env var (defaults to `true`). Set to `false` for local dev over plain HTTP.
- `internal/handler/auth.go` — `AuthHandler` accepts `secureCookies` param, passes to `setSessionCookie`/`clearSessionCookie`
- `internal/middleware/csrf.go` — `CSRF()` now takes `secureCookies bool` to control the cookie Secure flag
- `internal/middleware/csrf_test.go` — update all test calls to `CSRF(true)(...)`

## Test plan

- [x] `go test ./internal/...` — all tests pass
- [x] `go vet ./...`
- [x] Manual verification: cookies work over HTTP with `SECURE_COOKIES=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)